### PR TITLE
v_frame: Disable missing const fn clippy lint

### DIFF
--- a/v_frame/src/lib.rs
+++ b/v_frame/src/lib.rs
@@ -18,7 +18,6 @@
 #![allow(clippy::many_single_char_names)]
 // Performance lints
 #![warn(clippy::linkedlist)]
-#![warn(clippy::missing_const_for_fn)]
 #![warn(clippy::mutex_integer)]
 #![warn(clippy::suboptimal_flops)]
 // Correctness lints


### PR DESCRIPTION
Latest clippy results may not match minimum supported rustc.